### PR TITLE
Bypass re-encoding of JPEGs to speed up 3x and avoid loss of data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.0.5
+
+Feature: now able to add jpeg files directly without decoding and re-encoding
+which results in adding up the compression artefacts, unwanted loss of data and
+slower processing. Yield list of paths to the jpeg files instead of numpy arrays 
+in the adapter.
+
+Feature: Option to specify jpeg encode quality from the adapter. Define a function 
+`jpeg_encode_quality(self)` and return an integer in range (0,100]. It is backward 
+compatible because the `AbstractDatasetAdapter` class has a pre-defined value of 90.
+
 # v0.0.4
 
 Bugfix: `gulpio2.utils.burst_video_into_frames` extracted frames with the naming

--- a/src/gulpio2/__version__.py
+++ b/src/gulpio2/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "gulpio2"
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 __copyright__ = 'Copyright 2021 Will Price & TwentyBN'
 __description__ = "Binary storage format for deep learning on videos."
 __author__ = ", ".join("""\
@@ -12,6 +12,7 @@ Joanna Materzyńska (joanna.materzynska@twentybn.com)
 Florian Letsch (florian.letsch@twentybn.com)
 Valentin Haenel (valentin.haenel@twentybn.com)
 Will Price (will.price94+dev@gmail.com)
+Kiyoon Kim (yoonkr33@gmail.com)
 """.split("\n"))
 __author_email__ = "will.price94+gulpio2@gmail.com"
 __url__= "https://github.com/willprice/GulpIO2"

--- a/src/gulpio2/adapters.py
+++ b/src/gulpio2/adapters.py
@@ -33,6 +33,11 @@ class AbstractDatasetAdapter(ABC):  # pragma: no cover
 
     """
 
+    def jpeg_encode_quality(self):
+        # If you change the default value,
+        # the system_tests.py may fail checking the size of the output. 
+        return 90
+
     @abstractmethod
     def iter_data(self, slice_element=None):
         return NotImplementedError

--- a/src/gulpio2/utils.py
+++ b/src/gulpio2/utils.py
@@ -23,11 +23,11 @@ class FFMPEGNotFound(Exception):
     pass
 
 
-# If you update this, then the system_tests.py expected sizes will likely change.
-_JPEG_WRITE_QUALITY = 90
-
 def check_ffmpeg_exists():
     return os.system('ffmpeg -version > /dev/null') == 0
+
+
+_DEFAULT_JPEG_QUALITY = 90
 
 
 @contextmanager
@@ -39,7 +39,7 @@ def temp_dir_for_bursting(shm_dir_path='/dev/shm'):
     shutil.rmtree(temp_dir)
 
 
-def img_to_jpeg_bytes(img: np.ndarray) -> bytes:
+def img_to_jpeg_bytes(img: np.ndarray, jpeg_quality: int = _DEFAULT_JPEG_QUALITY) -> bytes:
     if img.ndim == 2:
         colorspace = "Gray"
         img = img[..., None]
@@ -47,7 +47,7 @@ def img_to_jpeg_bytes(img: np.ndarray) -> bytes:
         colorspace = "RGB"
     else:
         raise ValueError("Unsupported img shape: {}".format(img.shape))
-    return simplejpeg.encode_jpeg(img, quality=_JPEG_WRITE_QUALITY, colorspace=colorspace)
+    return simplejpeg.encode_jpeg(img, quality=jpeg_quality, colorspace=colorspace)
 
 
 def jpeg_bytes_to_img(jpeg_bytes: bytes) -> np.ndarray:


### PR DESCRIPTION
# Motivation
Many video datasets provide extracted jpeg format already, but the current GulpIO2 (v0.0.4) doesn't have a functionality to directly add the files without having to decode and re-encode them. It will slow down by 3 times when preparing the gulp directory, not to mention that there will be unwanted loss of data and compression artefacts.

# New Features

1. Now able to add jpeg files directly without decoding and re-encoding. Yield list of paths to the jpeg files instead of numpy arrays in the adapter.

2. Another change is the ability to specify jpeg encoding quality from the adapter. Define a function `jpeg_encode_quality(self)` and return an integer in range (0,100]. It is backward compatible because the `AbstractDatasetAdapter` class has a pre-defined value of 90.

# Benchmark

Here are the benchmark results using EPIC-Kitchens-100 dataset, generating optical flow training set gulp.

Re-encoding adapter can be found [here](https://github.com/epic-kitchens/C1-Action-Recognition-TSN-TRN-TSM/blob/2b7fa1894656e71dc5f8935213396b12c01b2eef/src/utils/gulp_adapter.py) and  
Modified adapter that bypasses re-encoding can be found [here](https://github.com/kiyoon/video_datasets_api/blob/d35e38e8a34aca0332553cd2d7e89c120c0c89a3/video_datasets_api/epic_kitchens_100/gulp_adapter.py).

Tested with the `AMD Ryzen 7 5800X 8-Core Processor` CPU and an NVME drive.

|GulpIO2 version|Re-encoding|Speed    |Final Size|
|---------------|-----------|---------|----------|
|0.0.5          |**No**     |**06:16**|**112GiB**|
|0.0.5          |Yes        |18:50    |78GiB     |
|0.0.4          |Yes        |18:52    |78GiB     |